### PR TITLE
fix(linux): playtime recording using wine

### DIFF
--- a/src-tauri/src/services/playtime/classic.rs
+++ b/src-tauri/src/services/playtime/classic.rs
@@ -1,5 +1,4 @@
 use super::super::stores::games::GamesStore;
-#[cfg(windows)]
 use crate::util::flush_playtime;
 use crate::{services::stores::settings::PlaytimeMode, AppState};
 use serde_json::json;
@@ -101,6 +100,12 @@ impl ClassicPlaytime {
                                     state.game.as_mut().ok_or("Couldn't find the game")?;
                                 game_state.current_playtime += 1;
                             }
+
+                            if current_playtime % 60 == 0 {
+                                flush_playtime(&app_handle, &game_id, 60)
+                                    .map_err(|_| "Error happened while updating playtime")?;
+                            }
+
                             app_handle
                                 .emit("playtime", current_playtime + 1)
                                 .map_err(|_| "Error happened while emitting playtime")?;

--- a/src-tauri/src/util.rs
+++ b/src-tauri/src/util.rs
@@ -37,6 +37,21 @@ pub fn get_pid_from_process_path(process_file_path: &str) -> Option<Pid> {
             if exe.to_str()? == process_file_path {
                 return Some(process.pid());
             }
+
+            #[cfg(not(windows))]
+            {
+                let normalized_path = process
+                    .cmd()
+                    .iter()
+                    .filter_map(|s| s.to_str())
+                    .collect::<Vec<&str>>()
+                    .join(" ")
+                    .replace("\\", "/");
+
+                if normalized_path.contains(process_file_path) {
+                    return Some(process.pid());
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #93 

Fixes playtime recording / game detection on games on Linux running through wine, by checking for **both** executable path (`/usr/bin/wine` etc in wine case) and command + arguments `argv` which would contain the actual game's path (gets normalized to convert from Windows path syntax to Linux)